### PR TITLE
computer.log and 16 millisecond delay.

### DIFF
--- a/src/apis/computer.lua
+++ b/src/apis/computer.lua
@@ -77,3 +77,7 @@ function env.computer.maxEnergy()
 	cprint("computer.maxEnergy")
 	return 1500
 end
+
+function env.computer.log(...)
+	print(...)
+end

--- a/src/boot.lua
+++ b/src/boot.lua
@@ -153,7 +153,7 @@ local function boot()
 			elsa.draw()
 		end
 
-		SDL.delay(1)
+		SDL.delay(16)
 	end
 end
 


### PR DESCRIPTION
I'm pretty sure we aren't supposed to be going at 1,000 fps.

Also, computer.log makes it easy to get logging output when making a Custom OS. Since the lower levels of an OS have no way to output status reliably (because fuck /tmp), this makes thing 100% easier for people and things.

{{GitHub.PullRequest.SellingPoint[3]}}
