### PR TITLE
Add my aur package to README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,10 @@ Grab the Lua 5.2, luarocks5.2, lua52-filesystem, lua52-sec & lua52-socket from t
 ```
 pacman -S lua52 luarocks5.2 lua52-filesystem lua52-sec lua52-socket
 ```
+
 Now follow the luarocks steps below to get the remaining libraries which are not on Arch's repos.
+
+Or install [ocemu](https://aur.archlinux.org/packages/ocemu/) from the AUR.
 
 
 **Mac**


### PR DESCRIPTION
So i just made a [aur package](https://aur.archlinux.org/packages/ocemu/) of ocemu for easier installation on Arch. I think it should be on the README but that might be just me.

Btw, i couldn't find any official "version", so i'm currently just using "0.0". How should i handle that?