### PR TITLE
Add computer.getDeviceInfo - untested, may need some fixes

### DIFF
--- a/src/apis/computer.lua
+++ b/src/apis/computer.lua
@@ -107,3 +107,24 @@ function env.computer.setArchitecture(archName)
 	end
 	return false
 end
+local template = {
+	gpu = {
+		capacity = 8000
+	},
+	screen = {
+		capacity = 8000
+	}
+}
+function env.computer.getDeviceInfo()
+	cprint("computer.getDeviceInfo")
+	local info = {}
+	for a, t in env.component.list() do
+		info[a] = {}
+		if template[t] then
+			for k, v in pairs(template[t]) do
+				info[a][k] = v
+			end
+		end
+	end
+	return info
+end


### PR DESCRIPTION
This is required for Monolith, and possibly PsychOS, to boot.